### PR TITLE
Prototype of `AllenOpt`

### DIFF
--- a/.allennlp_plugins
+++ b/.allennlp_plugins
@@ -1,0 +1,1 @@
+allenopt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+
+## Install
+
+```
+poetry install
+```
+
+## Run
+
+```
+poetry run allennlp allenopt config/imdb_optuna.jsonnet config/hparams.json \
+    --serialization-dir t
+```

--- a/allenopt/__init__.py
+++ b/allenopt/__init__.py
@@ -1,4 +1,3 @@
 from allenopt.commands import *  # noqa
 
-
 __version__ = "0.0.1"

--- a/allenopt/__init__.py
+++ b/allenopt/__init__.py
@@ -1,0 +1,4 @@
+from allenopt.commands import *  # noqa
+
+
+__version__ = "0.0.1"

--- a/allenopt/commands/__init__.py
+++ b/allenopt/commands/__init__.py
@@ -1,0 +1,1 @@
+from allenopt.commands.allenopt import AllenOpt  # noqa

--- a/allenopt/commands/allenopt.py
+++ b/allenopt/commands/allenopt.py
@@ -5,30 +5,51 @@ which to write the results.
 """
 
 import argparse
+import json
 import logging
-import os
-from os import PathLike
-from typing import Any, Dict, List, Optional, Union
+import os.path
+from functools import partial
 
-import torch
-import torch.distributed as dist
-import torch.multiprocessing as mp
+import optuna
+from allennlp.commands.subcommand import Subcommand
+from optuna import Trial
+from optuna.integration import AllenNLPExecutor
 from overrides import overrides
 
-from allennlp.commands.subcommand import Subcommand
-from allennlp.common import Params, Registrable, Lazy
-from allennlp.common.checks import check_for_gpu, ConfigurationError
-from allennlp.common import logging as common_logging
-from allennlp.common import util as common_util
-from allennlp.common.plugins import import_plugins
-from allennlp.data import DatasetReader, Vocabulary
-from allennlp.data import DataLoader
-from allennlp.models.archival import archive_model, CONFIG_NAME
-from allennlp.models.model import _DEFAULT_WEIGHTS, Model
-from allennlp.training.trainer import Trainer
-from allennlp.training import util as training_util
 
 logger = logging.getLogger(__name__)
+
+
+def optimize_hyperparameters(args: argparse.Namespace) -> None:
+    config_file = args.param_path
+    hparam_path = args.hparam_path
+    serialization_dir = args.serialization_dir
+
+    def _objective(
+        trial: Trial,
+        hparam_path: str,
+    ) -> float:
+
+        for hparam in json.load(open(hparam_path)):
+            attr_type = hparam["type"]
+            suggest = getattr(trial, "suggest_{}".format(attr_type))
+            suggest(**hparam["keyword"])
+
+        optuna_serialization_dir = os.path.join(serialization_dir, "trial_{}".format(trial.number))
+        executor = AllenNLPExecutor(trial, config_file, optuna_serialization_dir)
+        return executor.run()
+
+    study = optuna.create_study(
+        direction="maximize",
+        storage="sqlite:///allennlp.db",
+        pruner=optuna.pruners.HyperbandPruner(),
+    )
+
+    objective = partial(
+        _objective,
+        hparam_path=hparam_path,
+    )
+    study.optimize(objective, n_trials=50, timeout=600)
 
 
 @Subcommand.register("allenopt")
@@ -39,7 +60,16 @@ class AllenOpt(Subcommand):
         subparser = parser.add_parser(self.name, description=description, help="Train a model.")
 
         subparser.add_argument(
-            "param_path", type=str, help="path to parameter file describing the model to be trained"
+            "param_path",
+            type=str,
+            help="path to parameter file describing the model to be trained",
+        )
+
+        subparser.add_argument(
+            "hparam_path",
+            type=str,
+            help="path to hyperparameter file",
+            default="hyper_params.json",
         )
 
         subparser.add_argument(
@@ -50,634 +80,5 @@ class AllenOpt(Subcommand):
             help="directory in which to save the model and its logs",
         )
 
-        subparser.add_argument(
-            "-r",
-            "--recover",
-            action="store_true",
-            default=False,
-            help="recover training from the state in serialization_dir",
-        )
-
-        subparser.add_argument(
-            "-f",
-            "--force",
-            action="store_true",
-            required=False,
-            help="overwrite the output directory if it exists",
-        )
-
-        subparser.add_argument(
-            "-o",
-            "--overrides",
-            type=str,
-            default="",
-            help=(
-                "a json(net) structure used to override the experiment configuration, e.g., "
-                "'{\"iterator.batch_size\": 16}'.  Nested parameters can be specified either"
-                " with nested dictionaries or with dot syntax."
-            ),
-        )
-
-        subparser.add_argument(
-            "--node-rank", type=int, default=0, help="rank of this node in the distributed setup"
-        )
-
-        subparser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help=(
-                "do not train a model, but create a vocabulary, show dataset statistics and "
-                "other training information"
-            ),
-        )
-        subparser.add_argument(
-            "--file-friendly-logging",
-            action="store_true",
-            default=False,
-            help="outputs tqdm status on separate lines and slows tqdm refresh rate",
-        )
-
-        subparser.set_defaults(func=train_model_from_args)
-
+        subparser.set_defaults(func=optimize_hyperparameters)
         return subparser
-
-
-def train_model_from_args(args: argparse.Namespace):
-    """
-    Just converts from an `argparse.Namespace` object to string paths.
-    """
-    train_model_from_file(
-        parameter_filename=args.param_path,
-        serialization_dir=args.serialization_dir,
-        overrides=args.overrides,
-        recover=args.recover,
-        force=args.force,
-        node_rank=args.node_rank,
-        include_package=args.include_package,
-        dry_run=args.dry_run,
-        file_friendly_logging=args.file_friendly_logging,
-    )
-
-
-def train_model_from_file(
-    parameter_filename: Union[str, PathLike],
-    serialization_dir: Union[str, PathLike],
-    overrides: str = "",
-    recover: bool = False,
-    force: bool = False,
-    node_rank: int = 0,
-    include_package: List[str] = None,
-    dry_run: bool = False,
-    file_friendly_logging: bool = False,
-) -> Optional[Model]:
-    """
-    A wrapper around [`train_model`](#train_model) which loads the params from a file.
-    # Parameters
-    parameter_filename : `str`
-        A json parameter file specifying an AllenNLP experiment.
-    serialization_dir : `str`
-        The directory in which to save results and logs. We just pass this along to
-        [`train_model`](#train_model).
-    overrides : `str`
-        A JSON string that we will use to override values in the input parameter file.
-    recover : `bool`, optional (default=`False`)
-        If `True`, we will try to recover a training run from an existing serialization
-        directory.  This is only intended for use when something actually crashed during the middle
-        of a run.  For continuing training a model on new data, see `Model.from_archive`.
-    force : `bool`, optional (default=`False`)
-        If `True`, we will overwrite the serialization directory if it already exists.
-    node_rank : `int`, optional
-        Rank of the current node in distributed training
-    include_package : `str`, optional
-        In distributed mode, extra packages mentioned will be imported in trainer workers.
-    dry_run : `bool`, optional (default=`False`)
-        Do not train a model, but create a vocabulary, show dataset statistics and other training
-        information.
-    file_friendly_logging : `bool`, optional (default=`False`)
-        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
-        down tqdm's output to only once every 10 seconds.
-    # Returns
-    best_model : `Optional[Model]`
-        The model with the best epoch weights or `None` if in dry run.
-    """
-    # Load the experiment config from a file and pass it to `train_model`.
-    params = Params.from_file(parameter_filename, overrides)
-    return train_model(
-        params=params,
-        serialization_dir=serialization_dir,
-        recover=recover,
-        force=force,
-        node_rank=node_rank,
-        include_package=include_package,
-        dry_run=dry_run,
-        file_friendly_logging=file_friendly_logging,
-    )
-
-
-def train_model(
-    params: Params,
-    serialization_dir: Union[str, PathLike],
-    recover: bool = False,
-    force: bool = False,
-    node_rank: int = 0,
-    include_package: List[str] = None,
-    dry_run: bool = False,
-    file_friendly_logging: bool = False,
-) -> Optional[Model]:
-    """
-    Trains the model specified in the given [`Params`](../common/params.md#params) object, using the data
-    and training parameters also specified in that object, and saves the results in `serialization_dir`.
-    # Parameters
-    params : `Params`
-        A parameter object specifying an AllenNLP Experiment.
-    serialization_dir : `str`
-        The directory in which to save results and logs.
-    recover : `bool`, optional (default=`False`)
-        If `True`, we will try to recover a training run from an existing serialization
-        directory.  This is only intended for use when something actually crashed during the middle
-        of a run.  For continuing training a model on new data, see `Model.from_archive`.
-    force : `bool`, optional (default=`False`)
-        If `True`, we will overwrite the serialization directory if it already exists.
-    node_rank : `int`, optional
-        Rank of the current node in distributed training
-    include_package : `List[str]`, optional
-        In distributed mode, extra packages mentioned will be imported in trainer workers.
-    dry_run : `bool`, optional (default=`False`)
-        Do not train a model, but create a vocabulary, show dataset statistics and other training
-        information.
-    file_friendly_logging : `bool`, optional (default=`False`)
-        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
-        down tqdm's output to only once every 10 seconds.
-    # Returns
-    best_model : `Optional[Model]`
-        The model with the best epoch weights or `None` if in dry run.
-    """
-    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
-
-    training_util.create_serialization_dir(params, serialization_dir, recover, force)
-    params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
-
-    distributed_params = params.params.pop("distributed", None)
-    # If distributed isn't in the config and the config contains strictly
-    # one cuda device, we just run a single training process.
-    if distributed_params is None:
-        model = _train_worker(
-            process_rank=0,
-            params=params,
-            serialization_dir=serialization_dir,
-            include_package=include_package,
-            dry_run=dry_run,
-            file_friendly_logging=file_friendly_logging,
-        )
-
-        if not dry_run:
-            archive_model(serialization_dir)
-        return model
-
-    # Otherwise, we are running multiple processes for training.
-    else:
-        # We are careful here so that we can raise a good error if someone
-        # passed the wrong thing - cuda_devices are required.
-        device_ids = distributed_params.pop("cuda_devices", None)
-        multi_device = isinstance(device_ids, list) and len(device_ids) > 1
-        num_nodes = distributed_params.pop("num_nodes", 1)
-
-        if not (multi_device or num_nodes > 1):
-            raise ConfigurationError(
-                "Multiple cuda devices/nodes need to be configured to run distributed training."
-            )
-        check_for_gpu(device_ids)
-
-        master_addr = distributed_params.pop("master_address", "127.0.0.1")
-        master_port = distributed_params.pop("master_port", 29500)
-        num_procs = len(device_ids)
-        world_size = num_nodes * num_procs
-
-        # Creating `Vocabulary` objects from workers could be problematic since
-        # the data loaders in each worker will yield only `rank` specific
-        # instances. Hence it is safe to construct the vocabulary and write it
-        # to disk before initializing the distributed context. The workers will
-        # load the vocabulary from the path specified.
-        vocab_dir = os.path.join(serialization_dir, "vocabulary")
-        if recover:
-            vocab = Vocabulary.from_files(vocab_dir)
-        else:
-            vocab = training_util.make_vocab_from_params(
-                params.duplicate(), serialization_dir, print_statistics=dry_run
-            )
-        params["vocabulary"] = {
-            "type": "from_files",
-            "directory": vocab_dir,
-            "padding_token": vocab._padding_token,
-            "oov_token": vocab._oov_token,
-        }
-
-        logging.info(
-            "Switching to distributed training mode since multiple GPUs are configured | "
-            f"Master is at: {master_addr}:{master_port} | Rank of this node: {node_rank} | "
-            f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
-            f"World size: {world_size}"
-        )
-
-        mp.spawn(
-            _train_worker,
-            args=(
-                params.duplicate(),
-                serialization_dir,
-                include_package,
-                dry_run,
-                node_rank,
-                master_addr,
-                master_port,
-                world_size,
-                device_ids,
-                file_friendly_logging,
-            ),
-            nprocs=num_procs,
-        )
-        if dry_run:
-            return None
-        else:
-            archive_model(serialization_dir)
-            model = Model.load(params, serialization_dir)
-            return model
-
-
-def _train_worker(
-    process_rank: int,
-    params: Params,
-    serialization_dir: Union[str, PathLike],
-    include_package: List[str] = None,
-    dry_run: bool = False,
-    node_rank: int = 0,
-    master_addr: str = "127.0.0.1",
-    master_port: int = 29500,
-    world_size: int = 1,
-    distributed_device_ids: List[int] = None,
-    file_friendly_logging: bool = False,
-) -> Optional[Model]:
-    """
-    Helper to train the configured model/experiment. In distributed mode, this is spawned as a
-    worker process. In a single GPU experiment, this returns the `Model` object and in distributed
-    training, nothing is returned.
-    # Parameters
-    process_rank : `int`
-        The process index that is initialized using the GPU device id.
-    params : `Params`
-        A parameter object specifying an AllenNLP Experiment.
-    serialization_dir : `str`
-        The directory in which to save results and logs.
-    include_package : `List[str]`, optional
-        In distributed mode, since this function would have been spawned as a separate process,
-        the extra imports need to be done again. NOTE: This does not have any effect in single
-        GPU training.
-    dry_run : `bool`, optional (default=`False`)
-        Do not train a model, but create a vocabulary, show dataset statistics and other training
-        information.
-    node_rank : `int`, optional
-        Rank of the node.
-    master_addr : `str`, optional (default=`"127.0.0.1"`)
-        Address of the master node for distributed training.
-    master_port : `str`, optional (default=`"29500"`)
-        Port of the master node for distributed training.
-    world_size : `int`, optional
-        The number of processes involved in distributed training.
-    distributed_device_ids: `List[str]`, optional
-        IDs of the devices used involved in distributed training.
-    file_friendly_logging : `bool`, optional (default=`False`)
-        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
-        down tqdm's output to only once every 10 seconds.
-    # Returns
-    best_model : `Optional[Model]`
-        The model with the best epoch weights or `None` if in distributed training or in dry run.
-    """
-    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
-
-    common_logging.prepare_global_logging(
-        serialization_dir,
-        rank=process_rank,
-        world_size=world_size,
-    )
-    common_util.prepare_environment(params)
-
-    distributed = world_size > 1
-
-    # not using `allennlp.common.util.is_master` as the process group is yet to be initialized
-    master = process_rank == 0
-
-    include_package = include_package or []
-
-    if distributed:
-        # Since the worker is spawned and not forked, the extra imports need to be done again.
-        # Both the ones from the plugins and the ones from `include_package`.
-        import_plugins()
-        for package_name in include_package:
-            common_util.import_module_and_submodules(package_name)
-
-        num_procs_per_node = len(distributed_device_ids)
-        # The Unique identifier of the worker process among all the processes in the
-        # distributed training group is computed here. This is used while initializing
-        # the process group using `init_process_group`
-        global_rank = node_rank * num_procs_per_node + process_rank
-
-        # Number of processes per node is useful to know if a process
-        # is a master in the local node(node in which it is running)
-        os.environ["ALLENNLP_PROCS_PER_NODE"] = str(num_procs_per_node)
-
-        # In distributed training, the configured device is always going to be a list.
-        # The corresponding gpu id for the particular worker is obtained by picking the id
-        # from the device list with the rank as index
-        gpu_id = distributed_device_ids[process_rank]  # type: ignore
-
-        # Till now, "cuda_device" might not be set in the trainer params.
-        # But a worker trainer needs to only know about its specific GPU id.
-        params["trainer"]["cuda_device"] = gpu_id
-        params["trainer"]["world_size"] = world_size
-        params["trainer"]["distributed"] = True
-
-        if gpu_id >= 0:
-            torch.cuda.set_device(int(gpu_id))
-            dist.init_process_group(
-                backend="nccl",
-                init_method=f"tcp://{master_addr}:{master_port}",
-                world_size=world_size,
-                rank=global_rank,
-            )
-        else:
-            dist.init_process_group(
-                backend="gloo",
-                init_method=f"tcp://{master_addr}:{master_port}",
-                world_size=world_size,
-                rank=global_rank,
-            )
-        logging.info(
-            f"Process group of world size {world_size} initialized "
-            f"for distributed training in worker {global_rank}"
-        )
-
-    train_loop = TrainModel.from_params(
-        params=params,
-        serialization_dir=serialization_dir,
-        local_rank=process_rank,
-    )
-
-    if dry_run:
-        return None
-
-    try:
-        if distributed:  # let the setup get ready for all the workers
-            dist.barrier()
-
-        metrics = train_loop.run()
-    except KeyboardInterrupt:
-        # if we have completed an epoch, try to create a model archive.
-        if master and os.path.exists(os.path.join(serialization_dir, _DEFAULT_WEIGHTS)):
-            logging.info(
-                "Training interrupted by the user. Attempting to create "
-                "a model archive using the current best epoch weights."
-            )
-            archive_model(serialization_dir)
-        raise
-
-    if master:
-        train_loop.finish(metrics)
-
-    if not distributed:
-        return train_loop.model
-
-    return None
-
-
-class TrainModel(Registrable):
-    """
-    This class exists so that we can easily read a configuration file with the `allennlp train`
-    command.  The basic logic is that we call `train_loop =
-    TrainModel.from_params(params_from_config_file)`, then `train_loop.run()`.  This class performs
-    very little logic, pushing most of it to the `Trainer` that has a `train()` method.  The
-    point here is to construct all of the dependencies for the `Trainer` in a way that we can do
-    it using `from_params()`, while having all of those dependencies transparently documented and
-    not hidden in calls to `params.pop()`.  If you are writing your own training loop, you almost
-    certainly should not use this class, but you might look at the code for this class to see what
-    we do, to make writing your training loop easier.
-    In particular, if you are tempted to call the `__init__` method of this class, you are probably
-    doing something unnecessary.  Literally all we do after `__init__` is call `trainer.train()`.  You
-    can do that yourself, if you've constructed a `Trainer` already.  What this class gives you is a
-    way to construct the `Trainer` by means of a config file.  The actual constructor that we use
-    with `from_params` in this class is `from_partial_objects`.  See that method for a description
-    of all of the allowed top-level keys in a configuration file used with `allennlp train`.
-    """
-
-    default_implementation = "default"
-    """
-    The default implementation is registered as 'default'.
-    """
-
-    def __init__(
-        self,
-        serialization_dir: str,
-        model: Model,
-        trainer: Trainer,
-        evaluation_data_loader: DataLoader = None,
-        evaluate_on_test: bool = False,
-        batch_weight_key: str = "",
-    ) -> None:
-        self.serialization_dir = serialization_dir
-        self.model = model
-        self.trainer = trainer
-        self.evaluation_data_loader = evaluation_data_loader
-        self.evaluate_on_test = evaluate_on_test
-        self.batch_weight_key = batch_weight_key
-
-    def run(self) -> Dict[str, Any]:
-        return self.trainer.train()
-
-    def finish(self, metrics: Dict[str, Any]):
-        if self.evaluation_data_loader is not None and self.evaluate_on_test:
-            logger.info("The model will be evaluated using the best epoch weights.")
-            test_metrics = training_util.evaluate(
-                self.model,
-                self.evaluation_data_loader,
-                cuda_device=self.trainer.cuda_device,
-                batch_weight_key=self.batch_weight_key,
-            )
-
-            for key, value in test_metrics.items():
-                metrics["test_" + key] = value
-        elif self.evaluation_data_loader is not None:
-            logger.info(
-                "To evaluate on the test set after training, pass the "
-                "'evaluate_on_test' flag, or use the 'allennlp evaluate' command."
-            )
-        common_util.dump_metrics(
-            os.path.join(self.serialization_dir, "metrics.json"), metrics, log=True
-        )
-
-    @classmethod
-    def from_partial_objects(
-        cls,
-        serialization_dir: str,
-        local_rank: int,
-        dataset_reader: DatasetReader,
-        train_data_path: str,
-        model: Lazy[Model],
-        data_loader: Lazy[DataLoader],
-        trainer: Lazy[Trainer],
-        vocabulary: Lazy[Vocabulary] = None,
-        datasets_for_vocab_creation: List[str] = None,
-        validation_dataset_reader: DatasetReader = None,
-        validation_data_path: str = None,
-        validation_data_loader: Lazy[DataLoader] = None,
-        test_data_path: str = None,
-        evaluate_on_test: bool = False,
-        batch_weight_key: str = "",
-    ) -> "TrainModel":
-        """
-        This method is intended for use with our `FromParams` logic, to construct a `TrainModel`
-        object from a config file passed to the `allennlp train` command.  The arguments to this
-        method are the allowed top-level keys in a configuration file (except for the first three,
-        which are obtained separately).
-        You *could* use this outside of our `FromParams` logic if you really want to, but there
-        might be easier ways to accomplish your goal than instantiating `Lazy` objects.  If you are
-        writing your own training loop, we recommend that you look at the implementation of this
-        method for inspiration and possibly some utility functions you can call, but you very likely
-        should not use this method directly.
-        The `Lazy` type annotations here are a mechanism for building dependencies to an object
-        sequentially - the `TrainModel` object needs data, a model, and a trainer, but the model
-        needs to see the data before it's constructed (to create a vocabulary) and the trainer needs
-        the data and the model before it's constructed.  Objects that have sequential dependencies
-        like this are labeled as `Lazy` in their type annotations, and we pass the missing
-        dependencies when we call their `construct()` method, which you can see in the code below.
-        # Parameters
-        serialization_dir: `str`
-            The directory where logs and model archives will be saved.
-            In a typical AllenNLP configuration file, this parameter does not get an entry as a
-            top-level key, it gets passed in separately.
-        local_rank: `int`
-            The process index that is initialized using the GPU device id.
-            In a typical AllenNLP configuration file, this parameter does not get an entry as a
-            top-level key, it gets passed in separately.
-        dataset_reader: `DatasetReader`
-            The `DatasetReader` that will be used for training and (by default) for validation.
-        train_data_path: `str`
-            The file (or directory) that will be passed to `dataset_reader.read()` to construct the
-            training data.
-        model: `Lazy[Model]`
-            The model that we will train.  This is lazy because it depends on the `Vocabulary`;
-            after constructing the vocabulary we call `model.construct(vocab=vocabulary)`.
-        data_loader: `Lazy[DataLoader]`
-            The data_loader we use to batch instances from the dataset reader at training and (by
-            default) validation time. This is lazy because it takes a dataset in it's constructor.
-        trainer: `Lazy[Trainer]`
-            The `Trainer` that actually implements the training loop.  This is a lazy object because
-            it depends on the model that's going to be trained.
-        vocabulary: `Lazy[Vocabulary]`, optional (default=`None`)
-            The `Vocabulary` that we will use to convert strings in the data to integer ids (and
-            possibly set sizes of embedding matrices in the `Model`).  By default we construct the
-            vocabulary from the instances that we read.
-        datasets_for_vocab_creation: `List[str]`, optional (default=`None`)
-            If you pass in more than one dataset but don't want to use all of them to construct a
-            vocabulary, you can pass in this key to limit it.  Valid entries in the list are
-            "train", "validation" and "test".
-        validation_dataset_reader: `DatasetReader`, optional (default=`None`)
-            If given, we will use this dataset reader for the validation data instead of
-            `dataset_reader`.
-        validation_data_path: `str`, optional (default=`None`)
-            If given, we will use this data for computing validation metrics and early stopping.
-        validation_data_loader: `Lazy[DataLoader]`, optional (default=`None`)
-            If given, the data_loader we use to batch instances from the dataset reader at
-            validation and test time. This is lazy because it takes a dataset in it's constructor.
-        test_data_path: `str`, optional (default=`None`)
-            If given, we will use this as test data.  This makes it available for vocab creation by
-            default, but nothing else.
-        evaluate_on_test: `bool`, optional (default=`False`)
-            If given, we will evaluate the final model on this data at the end of training.  Note
-            that we do not recommend using this for actual test data in every-day experimentation;
-            you should only very rarely evaluate your model on actual test data.
-        batch_weight_key: `str`, optional (default=`""`)
-            The name of metric used to weight the loss on a per-batch basis.  This is only used
-            during evaluation on final test data, if you've specified `evaluate_on_test=True`.
-        """
-
-        datasets = training_util.read_all_datasets(
-            train_data_path=train_data_path,
-            dataset_reader=dataset_reader,
-            validation_dataset_reader=validation_dataset_reader,
-            validation_data_path=validation_data_path,
-            test_data_path=test_data_path,
-        )
-
-        if datasets_for_vocab_creation:
-            for key in datasets_for_vocab_creation:
-                if key not in datasets:
-                    raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {key}")
-
-            logger.info(
-                "From dataset instances, %s will be considered for vocabulary creation.",
-                ", ".join(datasets_for_vocab_creation),
-            )
-
-        instance_generator = (
-            instance
-            for key, dataset in datasets.items()
-            if datasets_for_vocab_creation is None or key in datasets_for_vocab_creation
-            for instance in dataset
-        )
-
-        vocabulary_ = vocabulary.construct(instances=instance_generator)
-        if not vocabulary_:
-            vocabulary_ = Vocabulary.from_instances(instance_generator)
-        model_ = model.construct(vocab=vocabulary_)
-
-        # Initializing the model can have side effect of expanding the vocabulary.
-        # Save the vocab only in the master. In the degenerate non-distributed
-        # case, we're trivially the master. In the distributed case this is safe
-        # to do without worrying about race conditions since saving and loading
-        # the vocab involves acquiring a file lock.
-        if common_util.is_master():
-            vocabulary_path = os.path.join(serialization_dir, "vocabulary")
-            vocabulary_.save_to_files(vocabulary_path)
-
-        for dataset in datasets.values():
-            dataset.index_with(model_.vocab)
-
-        data_loader_ = data_loader.construct(dataset=datasets["train"])
-        validation_data = datasets.get("validation")
-        if validation_data is not None:
-            # Because of the way Lazy[T] works, we can't check it's existence
-            # _before_ we've tried to construct it. It returns None if it is not
-            # present, so we try to construct it first, and then afterward back off
-            # to the data_loader configuration used for training if it returns None.
-            validation_data_loader_ = validation_data_loader.construct(dataset=validation_data)
-            if validation_data_loader_ is None:
-                validation_data_loader_ = data_loader.construct(dataset=validation_data)
-        else:
-            validation_data_loader_ = None
-
-        test_data = datasets.get("test")
-        if test_data is not None:
-            test_data_loader = validation_data_loader.construct(dataset=test_data)
-            if test_data_loader is None:
-                test_data_loader = data_loader.construct(dataset=test_data)
-        else:
-            test_data_loader = None
-
-        # We don't need to pass serialization_dir and local_rank here, because they will have been
-        # passed through the trainer by from_params already, because they were keyword arguments to
-        # construct this class in the first place.
-        trainer_ = trainer.construct(
-            model=model_,
-            data_loader=data_loader_,
-            validation_data_loader=validation_data_loader_,
-        )
-
-        return cls(
-            serialization_dir=serialization_dir,
-            model=model_,
-            trainer=trainer_,
-            evaluation_data_loader=test_data_loader,
-            evaluate_on_test=evaluate_on_test,
-            batch_weight_key=batch_weight_key,
-        )
-
-
-TrainModel.register("default", constructor="from_partial_objects")(TrainModel)

--- a/allenopt/commands/allenopt.py
+++ b/allenopt/commands/allenopt.py
@@ -1,0 +1,683 @@
+"""
+The `train` subcommand can be used to train a model.
+It requires a configuration file and a directory in
+which to write the results.
+"""
+
+import argparse
+import logging
+import os
+from os import PathLike
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from overrides import overrides
+
+from allennlp.commands.subcommand import Subcommand
+from allennlp.common import Params, Registrable, Lazy
+from allennlp.common.checks import check_for_gpu, ConfigurationError
+from allennlp.common import logging as common_logging
+from allennlp.common import util as common_util
+from allennlp.common.plugins import import_plugins
+from allennlp.data import DatasetReader, Vocabulary
+from allennlp.data import DataLoader
+from allennlp.models.archival import archive_model, CONFIG_NAME
+from allennlp.models.model import _DEFAULT_WEIGHTS, Model
+from allennlp.training.trainer import Trainer
+from allennlp.training import util as training_util
+
+logger = logging.getLogger(__name__)
+
+
+@Subcommand.register("allenopt")
+class AllenOpt(Subcommand):
+    @overrides
+    def add_subparser(self, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
+        description = """Train the specified model on the specified dataset."""
+        subparser = parser.add_parser(self.name, description=description, help="Train a model.")
+
+        subparser.add_argument(
+            "param_path", type=str, help="path to parameter file describing the model to be trained"
+        )
+
+        subparser.add_argument(
+            "-s",
+            "--serialization-dir",
+            required=True,
+            type=str,
+            help="directory in which to save the model and its logs",
+        )
+
+        subparser.add_argument(
+            "-r",
+            "--recover",
+            action="store_true",
+            default=False,
+            help="recover training from the state in serialization_dir",
+        )
+
+        subparser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            required=False,
+            help="overwrite the output directory if it exists",
+        )
+
+        subparser.add_argument(
+            "-o",
+            "--overrides",
+            type=str,
+            default="",
+            help=(
+                "a json(net) structure used to override the experiment configuration, e.g., "
+                "'{\"iterator.batch_size\": 16}'.  Nested parameters can be specified either"
+                " with nested dictionaries or with dot syntax."
+            ),
+        )
+
+        subparser.add_argument(
+            "--node-rank", type=int, default=0, help="rank of this node in the distributed setup"
+        )
+
+        subparser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help=(
+                "do not train a model, but create a vocabulary, show dataset statistics and "
+                "other training information"
+            ),
+        )
+        subparser.add_argument(
+            "--file-friendly-logging",
+            action="store_true",
+            default=False,
+            help="outputs tqdm status on separate lines and slows tqdm refresh rate",
+        )
+
+        subparser.set_defaults(func=train_model_from_args)
+
+        return subparser
+
+
+def train_model_from_args(args: argparse.Namespace):
+    """
+    Just converts from an `argparse.Namespace` object to string paths.
+    """
+    train_model_from_file(
+        parameter_filename=args.param_path,
+        serialization_dir=args.serialization_dir,
+        overrides=args.overrides,
+        recover=args.recover,
+        force=args.force,
+        node_rank=args.node_rank,
+        include_package=args.include_package,
+        dry_run=args.dry_run,
+        file_friendly_logging=args.file_friendly_logging,
+    )
+
+
+def train_model_from_file(
+    parameter_filename: Union[str, PathLike],
+    serialization_dir: Union[str, PathLike],
+    overrides: str = "",
+    recover: bool = False,
+    force: bool = False,
+    node_rank: int = 0,
+    include_package: List[str] = None,
+    dry_run: bool = False,
+    file_friendly_logging: bool = False,
+) -> Optional[Model]:
+    """
+    A wrapper around [`train_model`](#train_model) which loads the params from a file.
+    # Parameters
+    parameter_filename : `str`
+        A json parameter file specifying an AllenNLP experiment.
+    serialization_dir : `str`
+        The directory in which to save results and logs. We just pass this along to
+        [`train_model`](#train_model).
+    overrides : `str`
+        A JSON string that we will use to override values in the input parameter file.
+    recover : `bool`, optional (default=`False`)
+        If `True`, we will try to recover a training run from an existing serialization
+        directory.  This is only intended for use when something actually crashed during the middle
+        of a run.  For continuing training a model on new data, see `Model.from_archive`.
+    force : `bool`, optional (default=`False`)
+        If `True`, we will overwrite the serialization directory if it already exists.
+    node_rank : `int`, optional
+        Rank of the current node in distributed training
+    include_package : `str`, optional
+        In distributed mode, extra packages mentioned will be imported in trainer workers.
+    dry_run : `bool`, optional (default=`False`)
+        Do not train a model, but create a vocabulary, show dataset statistics and other training
+        information.
+    file_friendly_logging : `bool`, optional (default=`False`)
+        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+    # Returns
+    best_model : `Optional[Model]`
+        The model with the best epoch weights or `None` if in dry run.
+    """
+    # Load the experiment config from a file and pass it to `train_model`.
+    params = Params.from_file(parameter_filename, overrides)
+    return train_model(
+        params=params,
+        serialization_dir=serialization_dir,
+        recover=recover,
+        force=force,
+        node_rank=node_rank,
+        include_package=include_package,
+        dry_run=dry_run,
+        file_friendly_logging=file_friendly_logging,
+    )
+
+
+def train_model(
+    params: Params,
+    serialization_dir: Union[str, PathLike],
+    recover: bool = False,
+    force: bool = False,
+    node_rank: int = 0,
+    include_package: List[str] = None,
+    dry_run: bool = False,
+    file_friendly_logging: bool = False,
+) -> Optional[Model]:
+    """
+    Trains the model specified in the given [`Params`](../common/params.md#params) object, using the data
+    and training parameters also specified in that object, and saves the results in `serialization_dir`.
+    # Parameters
+    params : `Params`
+        A parameter object specifying an AllenNLP Experiment.
+    serialization_dir : `str`
+        The directory in which to save results and logs.
+    recover : `bool`, optional (default=`False`)
+        If `True`, we will try to recover a training run from an existing serialization
+        directory.  This is only intended for use when something actually crashed during the middle
+        of a run.  For continuing training a model on new data, see `Model.from_archive`.
+    force : `bool`, optional (default=`False`)
+        If `True`, we will overwrite the serialization directory if it already exists.
+    node_rank : `int`, optional
+        Rank of the current node in distributed training
+    include_package : `List[str]`, optional
+        In distributed mode, extra packages mentioned will be imported in trainer workers.
+    dry_run : `bool`, optional (default=`False`)
+        Do not train a model, but create a vocabulary, show dataset statistics and other training
+        information.
+    file_friendly_logging : `bool`, optional (default=`False`)
+        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+    # Returns
+    best_model : `Optional[Model]`
+        The model with the best epoch weights or `None` if in dry run.
+    """
+    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
+
+    training_util.create_serialization_dir(params, serialization_dir, recover, force)
+    params.to_file(os.path.join(serialization_dir, CONFIG_NAME))
+
+    distributed_params = params.params.pop("distributed", None)
+    # If distributed isn't in the config and the config contains strictly
+    # one cuda device, we just run a single training process.
+    if distributed_params is None:
+        model = _train_worker(
+            process_rank=0,
+            params=params,
+            serialization_dir=serialization_dir,
+            include_package=include_package,
+            dry_run=dry_run,
+            file_friendly_logging=file_friendly_logging,
+        )
+
+        if not dry_run:
+            archive_model(serialization_dir)
+        return model
+
+    # Otherwise, we are running multiple processes for training.
+    else:
+        # We are careful here so that we can raise a good error if someone
+        # passed the wrong thing - cuda_devices are required.
+        device_ids = distributed_params.pop("cuda_devices", None)
+        multi_device = isinstance(device_ids, list) and len(device_ids) > 1
+        num_nodes = distributed_params.pop("num_nodes", 1)
+
+        if not (multi_device or num_nodes > 1):
+            raise ConfigurationError(
+                "Multiple cuda devices/nodes need to be configured to run distributed training."
+            )
+        check_for_gpu(device_ids)
+
+        master_addr = distributed_params.pop("master_address", "127.0.0.1")
+        master_port = distributed_params.pop("master_port", 29500)
+        num_procs = len(device_ids)
+        world_size = num_nodes * num_procs
+
+        # Creating `Vocabulary` objects from workers could be problematic since
+        # the data loaders in each worker will yield only `rank` specific
+        # instances. Hence it is safe to construct the vocabulary and write it
+        # to disk before initializing the distributed context. The workers will
+        # load the vocabulary from the path specified.
+        vocab_dir = os.path.join(serialization_dir, "vocabulary")
+        if recover:
+            vocab = Vocabulary.from_files(vocab_dir)
+        else:
+            vocab = training_util.make_vocab_from_params(
+                params.duplicate(), serialization_dir, print_statistics=dry_run
+            )
+        params["vocabulary"] = {
+            "type": "from_files",
+            "directory": vocab_dir,
+            "padding_token": vocab._padding_token,
+            "oov_token": vocab._oov_token,
+        }
+
+        logging.info(
+            "Switching to distributed training mode since multiple GPUs are configured | "
+            f"Master is at: {master_addr}:{master_port} | Rank of this node: {node_rank} | "
+            f"Number of workers in this node: {num_procs} | Number of nodes: {num_nodes} | "
+            f"World size: {world_size}"
+        )
+
+        mp.spawn(
+            _train_worker,
+            args=(
+                params.duplicate(),
+                serialization_dir,
+                include_package,
+                dry_run,
+                node_rank,
+                master_addr,
+                master_port,
+                world_size,
+                device_ids,
+                file_friendly_logging,
+            ),
+            nprocs=num_procs,
+        )
+        if dry_run:
+            return None
+        else:
+            archive_model(serialization_dir)
+            model = Model.load(params, serialization_dir)
+            return model
+
+
+def _train_worker(
+    process_rank: int,
+    params: Params,
+    serialization_dir: Union[str, PathLike],
+    include_package: List[str] = None,
+    dry_run: bool = False,
+    node_rank: int = 0,
+    master_addr: str = "127.0.0.1",
+    master_port: int = 29500,
+    world_size: int = 1,
+    distributed_device_ids: List[int] = None,
+    file_friendly_logging: bool = False,
+) -> Optional[Model]:
+    """
+    Helper to train the configured model/experiment. In distributed mode, this is spawned as a
+    worker process. In a single GPU experiment, this returns the `Model` object and in distributed
+    training, nothing is returned.
+    # Parameters
+    process_rank : `int`
+        The process index that is initialized using the GPU device id.
+    params : `Params`
+        A parameter object specifying an AllenNLP Experiment.
+    serialization_dir : `str`
+        The directory in which to save results and logs.
+    include_package : `List[str]`, optional
+        In distributed mode, since this function would have been spawned as a separate process,
+        the extra imports need to be done again. NOTE: This does not have any effect in single
+        GPU training.
+    dry_run : `bool`, optional (default=`False`)
+        Do not train a model, but create a vocabulary, show dataset statistics and other training
+        information.
+    node_rank : `int`, optional
+        Rank of the node.
+    master_addr : `str`, optional (default=`"127.0.0.1"`)
+        Address of the master node for distributed training.
+    master_port : `str`, optional (default=`"29500"`)
+        Port of the master node for distributed training.
+    world_size : `int`, optional
+        The number of processes involved in distributed training.
+    distributed_device_ids: `List[str]`, optional
+        IDs of the devices used involved in distributed training.
+    file_friendly_logging : `bool`, optional (default=`False`)
+        If `True`, we add newlines to tqdm output, even on an interactive terminal, and we slow
+        down tqdm's output to only once every 10 seconds.
+    # Returns
+    best_model : `Optional[Model]`
+        The model with the best epoch weights or `None` if in distributed training or in dry run.
+    """
+    common_logging.FILE_FRIENDLY_LOGGING = file_friendly_logging
+
+    common_logging.prepare_global_logging(
+        serialization_dir,
+        rank=process_rank,
+        world_size=world_size,
+    )
+    common_util.prepare_environment(params)
+
+    distributed = world_size > 1
+
+    # not using `allennlp.common.util.is_master` as the process group is yet to be initialized
+    master = process_rank == 0
+
+    include_package = include_package or []
+
+    if distributed:
+        # Since the worker is spawned and not forked, the extra imports need to be done again.
+        # Both the ones from the plugins and the ones from `include_package`.
+        import_plugins()
+        for package_name in include_package:
+            common_util.import_module_and_submodules(package_name)
+
+        num_procs_per_node = len(distributed_device_ids)
+        # The Unique identifier of the worker process among all the processes in the
+        # distributed training group is computed here. This is used while initializing
+        # the process group using `init_process_group`
+        global_rank = node_rank * num_procs_per_node + process_rank
+
+        # Number of processes per node is useful to know if a process
+        # is a master in the local node(node in which it is running)
+        os.environ["ALLENNLP_PROCS_PER_NODE"] = str(num_procs_per_node)
+
+        # In distributed training, the configured device is always going to be a list.
+        # The corresponding gpu id for the particular worker is obtained by picking the id
+        # from the device list with the rank as index
+        gpu_id = distributed_device_ids[process_rank]  # type: ignore
+
+        # Till now, "cuda_device" might not be set in the trainer params.
+        # But a worker trainer needs to only know about its specific GPU id.
+        params["trainer"]["cuda_device"] = gpu_id
+        params["trainer"]["world_size"] = world_size
+        params["trainer"]["distributed"] = True
+
+        if gpu_id >= 0:
+            torch.cuda.set_device(int(gpu_id))
+            dist.init_process_group(
+                backend="nccl",
+                init_method=f"tcp://{master_addr}:{master_port}",
+                world_size=world_size,
+                rank=global_rank,
+            )
+        else:
+            dist.init_process_group(
+                backend="gloo",
+                init_method=f"tcp://{master_addr}:{master_port}",
+                world_size=world_size,
+                rank=global_rank,
+            )
+        logging.info(
+            f"Process group of world size {world_size} initialized "
+            f"for distributed training in worker {global_rank}"
+        )
+
+    train_loop = TrainModel.from_params(
+        params=params,
+        serialization_dir=serialization_dir,
+        local_rank=process_rank,
+    )
+
+    if dry_run:
+        return None
+
+    try:
+        if distributed:  # let the setup get ready for all the workers
+            dist.barrier()
+
+        metrics = train_loop.run()
+    except KeyboardInterrupt:
+        # if we have completed an epoch, try to create a model archive.
+        if master and os.path.exists(os.path.join(serialization_dir, _DEFAULT_WEIGHTS)):
+            logging.info(
+                "Training interrupted by the user. Attempting to create "
+                "a model archive using the current best epoch weights."
+            )
+            archive_model(serialization_dir)
+        raise
+
+    if master:
+        train_loop.finish(metrics)
+
+    if not distributed:
+        return train_loop.model
+
+    return None
+
+
+class TrainModel(Registrable):
+    """
+    This class exists so that we can easily read a configuration file with the `allennlp train`
+    command.  The basic logic is that we call `train_loop =
+    TrainModel.from_params(params_from_config_file)`, then `train_loop.run()`.  This class performs
+    very little logic, pushing most of it to the `Trainer` that has a `train()` method.  The
+    point here is to construct all of the dependencies for the `Trainer` in a way that we can do
+    it using `from_params()`, while having all of those dependencies transparently documented and
+    not hidden in calls to `params.pop()`.  If you are writing your own training loop, you almost
+    certainly should not use this class, but you might look at the code for this class to see what
+    we do, to make writing your training loop easier.
+    In particular, if you are tempted to call the `__init__` method of this class, you are probably
+    doing something unnecessary.  Literally all we do after `__init__` is call `trainer.train()`.  You
+    can do that yourself, if you've constructed a `Trainer` already.  What this class gives you is a
+    way to construct the `Trainer` by means of a config file.  The actual constructor that we use
+    with `from_params` in this class is `from_partial_objects`.  See that method for a description
+    of all of the allowed top-level keys in a configuration file used with `allennlp train`.
+    """
+
+    default_implementation = "default"
+    """
+    The default implementation is registered as 'default'.
+    """
+
+    def __init__(
+        self,
+        serialization_dir: str,
+        model: Model,
+        trainer: Trainer,
+        evaluation_data_loader: DataLoader = None,
+        evaluate_on_test: bool = False,
+        batch_weight_key: str = "",
+    ) -> None:
+        self.serialization_dir = serialization_dir
+        self.model = model
+        self.trainer = trainer
+        self.evaluation_data_loader = evaluation_data_loader
+        self.evaluate_on_test = evaluate_on_test
+        self.batch_weight_key = batch_weight_key
+
+    def run(self) -> Dict[str, Any]:
+        return self.trainer.train()
+
+    def finish(self, metrics: Dict[str, Any]):
+        if self.evaluation_data_loader is not None and self.evaluate_on_test:
+            logger.info("The model will be evaluated using the best epoch weights.")
+            test_metrics = training_util.evaluate(
+                self.model,
+                self.evaluation_data_loader,
+                cuda_device=self.trainer.cuda_device,
+                batch_weight_key=self.batch_weight_key,
+            )
+
+            for key, value in test_metrics.items():
+                metrics["test_" + key] = value
+        elif self.evaluation_data_loader is not None:
+            logger.info(
+                "To evaluate on the test set after training, pass the "
+                "'evaluate_on_test' flag, or use the 'allennlp evaluate' command."
+            )
+        common_util.dump_metrics(
+            os.path.join(self.serialization_dir, "metrics.json"), metrics, log=True
+        )
+
+    @classmethod
+    def from_partial_objects(
+        cls,
+        serialization_dir: str,
+        local_rank: int,
+        dataset_reader: DatasetReader,
+        train_data_path: str,
+        model: Lazy[Model],
+        data_loader: Lazy[DataLoader],
+        trainer: Lazy[Trainer],
+        vocabulary: Lazy[Vocabulary] = None,
+        datasets_for_vocab_creation: List[str] = None,
+        validation_dataset_reader: DatasetReader = None,
+        validation_data_path: str = None,
+        validation_data_loader: Lazy[DataLoader] = None,
+        test_data_path: str = None,
+        evaluate_on_test: bool = False,
+        batch_weight_key: str = "",
+    ) -> "TrainModel":
+        """
+        This method is intended for use with our `FromParams` logic, to construct a `TrainModel`
+        object from a config file passed to the `allennlp train` command.  The arguments to this
+        method are the allowed top-level keys in a configuration file (except for the first three,
+        which are obtained separately).
+        You *could* use this outside of our `FromParams` logic if you really want to, but there
+        might be easier ways to accomplish your goal than instantiating `Lazy` objects.  If you are
+        writing your own training loop, we recommend that you look at the implementation of this
+        method for inspiration and possibly some utility functions you can call, but you very likely
+        should not use this method directly.
+        The `Lazy` type annotations here are a mechanism for building dependencies to an object
+        sequentially - the `TrainModel` object needs data, a model, and a trainer, but the model
+        needs to see the data before it's constructed (to create a vocabulary) and the trainer needs
+        the data and the model before it's constructed.  Objects that have sequential dependencies
+        like this are labeled as `Lazy` in their type annotations, and we pass the missing
+        dependencies when we call their `construct()` method, which you can see in the code below.
+        # Parameters
+        serialization_dir: `str`
+            The directory where logs and model archives will be saved.
+            In a typical AllenNLP configuration file, this parameter does not get an entry as a
+            top-level key, it gets passed in separately.
+        local_rank: `int`
+            The process index that is initialized using the GPU device id.
+            In a typical AllenNLP configuration file, this parameter does not get an entry as a
+            top-level key, it gets passed in separately.
+        dataset_reader: `DatasetReader`
+            The `DatasetReader` that will be used for training and (by default) for validation.
+        train_data_path: `str`
+            The file (or directory) that will be passed to `dataset_reader.read()` to construct the
+            training data.
+        model: `Lazy[Model]`
+            The model that we will train.  This is lazy because it depends on the `Vocabulary`;
+            after constructing the vocabulary we call `model.construct(vocab=vocabulary)`.
+        data_loader: `Lazy[DataLoader]`
+            The data_loader we use to batch instances from the dataset reader at training and (by
+            default) validation time. This is lazy because it takes a dataset in it's constructor.
+        trainer: `Lazy[Trainer]`
+            The `Trainer` that actually implements the training loop.  This is a lazy object because
+            it depends on the model that's going to be trained.
+        vocabulary: `Lazy[Vocabulary]`, optional (default=`None`)
+            The `Vocabulary` that we will use to convert strings in the data to integer ids (and
+            possibly set sizes of embedding matrices in the `Model`).  By default we construct the
+            vocabulary from the instances that we read.
+        datasets_for_vocab_creation: `List[str]`, optional (default=`None`)
+            If you pass in more than one dataset but don't want to use all of them to construct a
+            vocabulary, you can pass in this key to limit it.  Valid entries in the list are
+            "train", "validation" and "test".
+        validation_dataset_reader: `DatasetReader`, optional (default=`None`)
+            If given, we will use this dataset reader for the validation data instead of
+            `dataset_reader`.
+        validation_data_path: `str`, optional (default=`None`)
+            If given, we will use this data for computing validation metrics and early stopping.
+        validation_data_loader: `Lazy[DataLoader]`, optional (default=`None`)
+            If given, the data_loader we use to batch instances from the dataset reader at
+            validation and test time. This is lazy because it takes a dataset in it's constructor.
+        test_data_path: `str`, optional (default=`None`)
+            If given, we will use this as test data.  This makes it available for vocab creation by
+            default, but nothing else.
+        evaluate_on_test: `bool`, optional (default=`False`)
+            If given, we will evaluate the final model on this data at the end of training.  Note
+            that we do not recommend using this for actual test data in every-day experimentation;
+            you should only very rarely evaluate your model on actual test data.
+        batch_weight_key: `str`, optional (default=`""`)
+            The name of metric used to weight the loss on a per-batch basis.  This is only used
+            during evaluation on final test data, if you've specified `evaluate_on_test=True`.
+        """
+
+        datasets = training_util.read_all_datasets(
+            train_data_path=train_data_path,
+            dataset_reader=dataset_reader,
+            validation_dataset_reader=validation_dataset_reader,
+            validation_data_path=validation_data_path,
+            test_data_path=test_data_path,
+        )
+
+        if datasets_for_vocab_creation:
+            for key in datasets_for_vocab_creation:
+                if key not in datasets:
+                    raise ConfigurationError(f"invalid 'dataset_for_vocab_creation' {key}")
+
+            logger.info(
+                "From dataset instances, %s will be considered for vocabulary creation.",
+                ", ".join(datasets_for_vocab_creation),
+            )
+
+        instance_generator = (
+            instance
+            for key, dataset in datasets.items()
+            if datasets_for_vocab_creation is None or key in datasets_for_vocab_creation
+            for instance in dataset
+        )
+
+        vocabulary_ = vocabulary.construct(instances=instance_generator)
+        if not vocabulary_:
+            vocabulary_ = Vocabulary.from_instances(instance_generator)
+        model_ = model.construct(vocab=vocabulary_)
+
+        # Initializing the model can have side effect of expanding the vocabulary.
+        # Save the vocab only in the master. In the degenerate non-distributed
+        # case, we're trivially the master. In the distributed case this is safe
+        # to do without worrying about race conditions since saving and loading
+        # the vocab involves acquiring a file lock.
+        if common_util.is_master():
+            vocabulary_path = os.path.join(serialization_dir, "vocabulary")
+            vocabulary_.save_to_files(vocabulary_path)
+
+        for dataset in datasets.values():
+            dataset.index_with(model_.vocab)
+
+        data_loader_ = data_loader.construct(dataset=datasets["train"])
+        validation_data = datasets.get("validation")
+        if validation_data is not None:
+            # Because of the way Lazy[T] works, we can't check it's existence
+            # _before_ we've tried to construct it. It returns None if it is not
+            # present, so we try to construct it first, and then afterward back off
+            # to the data_loader configuration used for training if it returns None.
+            validation_data_loader_ = validation_data_loader.construct(dataset=validation_data)
+            if validation_data_loader_ is None:
+                validation_data_loader_ = data_loader.construct(dataset=validation_data)
+        else:
+            validation_data_loader_ = None
+
+        test_data = datasets.get("test")
+        if test_data is not None:
+            test_data_loader = validation_data_loader.construct(dataset=test_data)
+            if test_data_loader is None:
+                test_data_loader = data_loader.construct(dataset=test_data)
+        else:
+            test_data_loader = None
+
+        # We don't need to pass serialization_dir and local_rank here, because they will have been
+        # passed through the trainer by from_params already, because they were keyword arguments to
+        # construct this class in the first place.
+        trainer_ = trainer.construct(
+            model=model_,
+            data_loader=data_loader_,
+            validation_data_loader=validation_data_loader_,
+        )
+
+        return cls(
+            serialization_dir=serialization_dir,
+            model=model_,
+            trainer=trainer_,
+            evaluation_data_loader=test_data_loader,
+            evaluate_on_test=evaluate_on_test,
+            batch_weight_key=batch_weight_key,
+        )
+
+
+TrainModel.register("default", constructor="from_partial_objects")(TrainModel)

--- a/config/hparams.json
+++ b/config/hparams.json
@@ -1,0 +1,51 @@
+[
+    {
+        "type": "int",
+        "keyword": {
+            "name": "embedding_dim",
+            "low": 64,
+            "high": 128
+        }
+    },
+    {
+        "type": "int",
+        "keyword": {
+            "name": "max_filter_size",
+            "low": 2,
+            "high": 5
+        }
+    },
+    {
+        "type": "int",
+        "keyword": {
+            "name": "num_filters",
+            "low": 64,
+            "high": 256
+        }
+    },
+    {
+        "type": "int",
+        "keyword": {
+            "name": "output_dim",
+            "low": 64,
+            "high": 256
+        }
+    },
+    {
+        "type": "float",
+        "keyword": {
+            "name": "dropout",
+            "low": 0.0,
+            "high": 0.5
+        }
+    },
+    {
+        "type": "float",
+        "keyword": {
+            "name": "lr",
+            "low": 5e-3,
+            "high": 5e-1,
+            "log": true
+        }
+    }
+]

--- a/config/imdb_optuna.jsonnet
+++ b/config/imdb_optuna.jsonnet
@@ -1,0 +1,66 @@
+
+local batch_size = 64;
+local cuda_device = -1;
+local num_epochs = 15;
+local seed = 42;
+
+local embedding_dim = std.parseInt(std.extVar('embedding_dim'));
+local dropout = std.parseJson(std.extVar('dropout'));
+local lr = std.parseJson(std.extVar('lr'));
+local max_filter_size = std.parseInt(std.extVar('max_filter_size'));
+local num_filters = std.parseInt(std.extVar('num_filters'));
+local output_dim = std.parseInt(std.extVar('output_dim'));
+local ngram_filter_sizes = std.range(2, max_filter_size);
+
+{
+  numpy_seed: seed,
+  pytorch_seed: seed,
+  random_seed: seed,
+  dataset_reader: {
+    lazy: false,
+    type: 'text_classification_json',
+    tokenizer: {
+      type: 'spacy',
+    },
+    token_indexers: {
+      tokens: {
+        type: 'single_id',
+        lowercase_tokens: true,
+      },
+    },
+  },
+  datasets_for_vocab_creation: ['train'],
+  train_data_path: 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/train.jsonl',
+  validation_data_path: 'https://s3-us-west-2.amazonaws.com/allennlp/datasets/imdb/dev.jsonl',
+  model: {
+    type: 'basic_classifier',
+    text_field_embedder: {
+      token_embedders: {
+        tokens: {
+          embedding_dim: embedding_dim,
+        },
+      },
+    },
+    seq2vec_encoder: {
+      type: 'cnn',
+      embedding_dim: embedding_dim,
+      ngram_filter_sizes: ngram_filter_sizes,
+      num_filters: num_filters,
+      output_dim: output_dim,
+    },
+    dropout: dropout,
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: batch_size,
+  },
+  trainer: {
+    cuda_device: cuda_device,
+    num_epochs: num_epochs,
+    optimizer: {
+      lr: lr,
+      type: 'sgd',
+    },
+    validation_metric: '+accuracy',
+  },
+}


### PR DESCRIPTION
This PR introduce `AllenOpt`, the early prototype of Optuna integration for AllenNLP as `allennlp` subcommand.

## Run

```shell
poetry run allennlp allenopt \
    config/imdb_optuna.jsonnet \
    config/hparams.json \
    --serialization-dir out
```

## Optuna specific parameters

- How to specify sampler and pruner

## Plugin registration

- `.allennlp_plugins` is required to register `allenopt` as a subcommand of `allennlp` except to some default plugins
  - detail: [allenai/allennlp/allennlp/common/plugins.py#L21](https://github.com/allenai/allennlp/blob/bf3206a28cd504d91ccd4a8fdbd07cbf549e2f2f/allennlp/common/plugins.py#L21)