### PR TITLE
Change syntax of hyperparameter search space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
+# AllenOpt: AllenNLP subcommand for hyperparameter optimization
 
-## Install
 
-```
-poetry install
-```
-
-## Run
+## 0. Install
 
 ```
-poetry run allennlp allenopt \
-    config/imdb_optuna.jsonnet \
-    config/hparams.json \
-    --optuna-config config/optuna.json  # settings for Optuna
-    --serialization-dir out
+pip install allenopt @ https://github.com/himkt/allenopt.git@master
 ```
 
 
-## AllenNLP config
+## 1. Optimization
+
+
+### 1.1 AllenNLP config
 
 Model configuration written in Jsonnet.
 
@@ -32,22 +27,100 @@ local lr = std.parseJson(std.extVar('lr'));  // after
 For more information, please refer to [AllenNLP Guide](https://guide.allennlp.org/hyperparameter-optimization).
 
 
-## Hyperparameter search space
+### 1.2 Define hyperparameter search speaces
 
 You can define search space in Json.
 
 Each hyperparameter config must have `type` and `keyword`.
-You can see what parameters are available for each hyperparameter in [Optuna API reference](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial).
+You can see what parameters are available for each hyperparameter in
+[Optuna API reference](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial).
 
-Parameters for `suggest_#{type}` are available for config of `type=#{type}`. (e.g. when `type=float`, you can see the available parameters in [suggest_float](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_float)
+```json
+[
+  {
+    "type": "int",
+    "attributes": {
+      "name": "embedding_dim",
+      "low": 64,
+      "high": 128
+    }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "max_filter_size",
+      "low": 2,
+      "high": 5
+    }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "num_filters",
+      "low": 64,
+      "high": 256
+    }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "output_dim",
+      "low": 64,
+      "high": 256
+    }
+  },
+  {
+    "type": "float",
+    "attributes": {
+      "name": "dropout",
+      "low": 0.0,
+      "high": 0.5
+    }
+  },
+  {
+    "type": "float",
+    "attributes": {
+      "name": "lr",
+      "low": 5e-3,
+      "high": 5e-1,
+      "log": true
+    }
+  }
+]
+```
+
+Parameters for `suggest_#{type}` are available for config of `type=#{type}`. (e.g. when `type=float`,
+you can see the available parameters in [suggest\_float](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.trial.Trial.html#optuna.trial.Trial.suggest_float)
 
 Please see the [example](./config/hparams.json) in detail.
 
 
-## Optuna config
+## 1.3 [Optional] Specify Optuna configurations
 
-You can choose pruners and samplers implemented in Optuna here.
+If you want to specify some Optuna specific configurations
+(such as sampling algorithms or pruning algorithms),
+it is possible to use `--optuna-config` option.
 
-The [example](./config/optuna.json) shows the usage of allenopt with
-[`Hyperband`](https://jmlr.org/papers/v18/16-558.html) and
-[`TPESampler`](https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization).
+The example of [optuna.json](./config/optuna.json) shows the usage of allenopt with
+
+
+## 1.4 Optimize hyperparameters by allennlp cli
+
+```shell
+poetry run allennlp allenopt \
+    config/imdb_optuna.jsonnet \
+    config/hparams.json \
+    --optuna-config config/optuna.json \
+    --serialization-dir result \
+    --study-name test \
+    --storage sqlite:///allenopt.db
+```
+
+
+## 2. Get best hyperparameters
+
+```shell
+poetry run allennlp best-params \
+    --study-name test
+    --storage sqlite:///allenopt.db
+```

--- a/allenopt/commands/allenopt.py
+++ b/allenopt/commands/allenopt.py
@@ -43,7 +43,7 @@ def optimize_hyperparameters(args: argparse.Namespace) -> None:
         for hparam in json.load(open(hparam_path)):
             attr_type = hparam["type"]
             suggest = getattr(trial, "suggest_{}".format(attr_type))
-            suggest(**hparam["keyword"])
+            suggest(**hparam["attributes"])
 
         optuna_serialization_dir = os.path.join(serialization_dir, "trial_{}".format(trial.number))
         executor = AllenNLPExecutor(trial, config_file, optuna_serialization_dir, metrics=metrics)
@@ -56,13 +56,13 @@ def optimize_hyperparameters(args: argparse.Namespace) -> None:
 
     if "pruner" in optuna_config:
         pruner_class = getattr(optuna.pruners, optuna_config["pruner"]["type"])
-        pruner = pruner_class(**optuna_config["pruner"]["keyword"])
+        pruner = pruner_class(**optuna_config["pruner"]["attributes"])
     else:
         pruner = None
 
     if "sampler" in optuna_config:
         sampler_class = getattr(optuna.samplers, optuna_config["sampler"]["type"])
-        sampler = sampler_class(optuna_config["sampler"]["keyword"])
+        sampler = sampler_class(optuna_config["sampler"]["attributes"])
     else:
         sampler = None
 

--- a/config/hparams.json
+++ b/config/hparams.json
@@ -1,51 +1,51 @@
 [
-    {
-        "type": "int",
-        "attributes": {
-            "name": "embedding_dim",
-            "low": 64,
-            "high": 128
-        }
-    },
-    {
-        "type": "int",
-        "attributes": {
-            "name": "max_filter_size",
-            "low": 2,
-            "high": 5
-        }
-    },
-    {
-        "type": "int",
-        "attributes": {
-            "name": "num_filters",
-            "low": 64,
-            "high": 256
-        }
-    },
-    {
-        "type": "int",
-        "attributes": {
-            "name": "output_dim",
-            "low": 64,
-            "high": 256
-        }
-    },
-    {
-        "type": "float",
-        "attributes": {
-            "name": "dropout",
-            "low": 0.0,
-            "high": 0.5
-        }
-    },
-    {
-        "type": "float",
-        "attributes": {
-            "name": "lr",
-            "low": 5e-3,
-            "high": 5e-1,
-            "log": true
-        }
+  {
+    "type": "int",
+    "attributes": {
+      "name": "embedding_dim",
+      "low": 64,
+      "high": 128
     }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "max_filter_size",
+      "low": 2,
+      "high": 5
+    }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "num_filters",
+      "low": 64,
+      "high": 256
+    }
+  },
+  {
+    "type": "int",
+    "attributes": {
+      "name": "output_dim",
+      "low": 64,
+      "high": 256
+    }
+  },
+  {
+    "type": "float",
+    "attributes": {
+      "name": "dropout",
+      "low": 0.0,
+      "high": 0.5
+    }
+  },
+  {
+    "type": "float",
+    "attributes": {
+      "name": "lr",
+      "low": 5e-3,
+      "high": 5e-1,
+      "log": true
+    }
+  }
 ]

--- a/config/hparams.json
+++ b/config/hparams.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "int",
-        "keyword": {
+        "attributes": {
             "name": "embedding_dim",
             "low": 64,
             "high": 128
@@ -9,7 +9,7 @@
     },
     {
         "type": "int",
-        "keyword": {
+        "attributes": {
             "name": "max_filter_size",
             "low": 2,
             "high": 5
@@ -17,7 +17,7 @@
     },
     {
         "type": "int",
-        "keyword": {
+        "attributes": {
             "name": "num_filters",
             "low": 64,
             "high": 256
@@ -25,7 +25,7 @@
     },
     {
         "type": "int",
-        "keyword": {
+        "attributes": {
             "name": "output_dim",
             "low": 64,
             "high": 256
@@ -33,7 +33,7 @@
     },
     {
         "type": "float",
-        "keyword": {
+        "attributes": {
             "name": "dropout",
             "low": 0.0,
             "high": 0.5
@@ -41,7 +41,7 @@
     },
     {
         "type": "float",
-        "keyword": {
+        "attributes": {
             "name": "lr",
             "low": 5e-3,
             "high": 5e-1,


### PR DESCRIPTION
## Before

```json
[
    {
        "type": "int",
        "keyword": {
            "name": "embedding_dim",
            "low": 64,
            "high": 128
        }
    }
]
```

## After

```json
[
    {
        "type": "int",
        "attributes": {
            "name": "embedding_dim",
            "low": 64,
            "high": 128
        }
    }
]
```