### PR TITLE
Fix naming

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ Then you have to create ``.allennlp_plugins``.
 
 .. code-block:: bash
 
-    echo 'allennlp-optuna' >> .allennlp_plugins
+    echo 'allennlp_optuna' >> .allennlp_plugins
 
 You can check if allennlp-optuna is successfully installed by running ``allennlp --help``.
 


### PR DESCRIPTION
Thanks for the great repo!
This is a minor fix in an installation document where the name of the plugin is somewhat incompatible.

Current installation
```
mkdir sandbox
cd sandbox
virtualenv py3 --python=/usr/bin/python3
source py3/bin/activate
pip install allennlp-optuna
echo 'allennlp-optuna' >> .allennlp_plugins
allennlp -h

2020-11-14 08:08:59,820 - ERROR - allennlp.common.plugins - Plugin allennlp-optuna could not be loaded: No module named 'allennlp-optuna'
```

With this fix
```
mkdir sandbox
cd sandbox
virtualenv py3 --python=/usr/bin/python3
source py3/bin/activate
pip install allennlp-optuna
echo 'allennlp_optuna' >> .allennlp_plugins
allennlp -h

2020-11-14 08:22:25,899 - INFO - allennlp.common.plugins - Plugin allennlp_optuna available
```
