### PR TITLE
Fix typo in allennlp plugins instruction of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install allennlp_optuna
 
 # Create .allennlp_plugins at the top of your repository or $HOME/.allennlp/plugins
 # For more information, please see https://github.com/allenai/allennlp#plugins
-echo 'allennlp-optuna' >> .allennlp_plugins
+echo 'allennlp_optuna' >> .allennlp_plugins
 ```
 
 


### PR DESCRIPTION
In the installation instructions of the readme, users are told to run:

`echo 'allennlp-optuna' >> .allennlp_plugins`

This is a typo, and should read:

`echo 'allennlp_optuna' >> .allennlp_plugins`

Otherwise, AllenNLP will complain

`ERROR - allennlp.common.plugins - Plugin allennlp-optuna could not be loaded: No module named 'allennlp-optuna'`