### PR TITLE
Remove `poetry run` on docs

### DIFF
--- a/docs/source/tutorial/advanced_optuna_configuration.rst
+++ b/docs/source/tutorial/advanced_optuna_configuration.rst
@@ -107,7 +107,7 @@ Finally, you can run optimization with pruning:
 
 .. code-block:: bash
 
-    poetry run allennlp tune \
+    allennlp tune \
         imdb_optuna_with_pruning.jsonnet \
         hparams.json \
         --optuna-param-path optuna.json \

--- a/docs/source/tutorial/hyperparameter_optimization_at_scale.rst
+++ b/docs/source/tutorial/hyperparameter_optimization_at_scale.rst
@@ -8,7 +8,7 @@ You can easily run distributed optimization by adding an option
 
 .. code-block:: bash
 
-    poetry run allennlp tune \
+    allennlp tune \
         imdb_optuna.jsonnet \
         hparams.json \
         --optuna-param-path optuna.json \
@@ -25,7 +25,7 @@ the command should be like following:
 
 .. code-block:: bash
 
-    poetry run allennlp tune \
+    allennlp tune \
         imdb_optuna.jsonnet \
         hparams.json \
         --optuna-param-path optuna.json \

--- a/docs/source/tutorial/run_allennlp_optuna.rst
+++ b/docs/source/tutorial/run_allennlp_optuna.rst
@@ -9,7 +9,7 @@ You can optimize hyperparameters by:
 
 .. code-block:: bash
 
-    poetry run allennlp tune \
+    allennlp tune \
         imdb_optuna.jsonnet \
         hparams.json \
         --serialization-dir result \
@@ -21,7 +21,7 @@ Get best hyperparameters
 
 .. code-block:: bash
 
-    poetry run allennlp best-params \
+    allennlp best-params \
         --study-name test
 
 
@@ -30,7 +30,7 @@ Retrain a model with optimized hyperparameters
 
 .. code-block:: bash
 
-    poetry run allennlp retrain \
+    allennlp retrain \
         imdb_optuna.jsonnet \
         --serialization-dir retrain_result \
         --study-name test


### PR DESCRIPTION
Follow-up for #27.

This PR removes `poetry run` on docs.