### PR TITLE
tune: Add option to continue even when exception is raised

### DIFF
--- a/allennlp_optuna/commands/tune.py
+++ b/allennlp_optuna/commands/tune.py
@@ -33,6 +33,7 @@ def tune(args: argparse.Namespace) -> None:
     study_name = args.study_name
     storage = args.storage
     metrics = args.metrics
+    skip_exception = args.skip_exception
 
     os.makedirs(serialization_dir, exist_ok=True)
 
@@ -86,7 +87,12 @@ def tune(args: argparse.Namespace) -> None:
         _objective,
         hparam_path=hparam_path,
     )
-    study.optimize(objective, n_trials=n_trials, timeout=timeout)
+    study.optimize(
+        objective,
+        n_trials=n_trials,
+        timeout=timeout,
+        catch=(Exception,) if skip_exception else (),
+    )
 
 
 @Subcommand.register("tune")
@@ -174,6 +180,15 @@ class Tune(Subcommand):
             type=str,
             help="The metrics you want to optimize.",
             default="best_validation_loss",
+        )
+
+        subparser.add_argument(
+            "--skip-exception",
+            action="store_true",
+            help=(
+                "If this option is specified, optimization won't stop even when it catches an exception."
+                " Note that this option is experimental and it could be changed or removed in future development."
+            ),
         )
 
         subparser.set_defaults(func=tune)


### PR DESCRIPTION
This PR allows users to continue their optimization even when some exception is raised.
This is typically useful when a loss becomes `nan`.

In Optuna, we can specify exceptions to catch in optimization, which enables users to continue their processes after specified exception is raised (🔗[official doc](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.optimize)). However, `allennlp-optuna` wraps Optuna API and it would be difficult to let users to specify exceptions through command line arguments.

So, in this PR, I simply add the option `--skip-exception` to catch all exceptions continue optimization after exception.

**This change is experimental.**