### PR TITLE
CI: Drop python36 and add python39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
AllenNLP no longer works with Python3.6.
https://github.com/himkt/allennlp-optuna/runs/4297619565?check_suite_focus=true